### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/servicenow-itsm.json
+++ b/templates/servicenow-itsm.json
@@ -219,7 +219,7 @@
                     ]
                 },
                 "Timeout": 10,
-                "Runtime": "nodejs6.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "KeepServiceNowCreateIncidentWarmEventRule": {
@@ -407,7 +407,7 @@
                     ]
                 },
                 "Timeout": 10,
-                "Runtime": "nodejs6.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "KeepServiceNowCreateIncidentByPhoneWarmEventRule": {
@@ -595,7 +595,7 @@
                     ]
                 },
                 "Timeout": 10,
-                "Runtime": "nodejs6.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "KeepServiceNowGetIncidentByPhoneWarmEventRule": {
@@ -783,7 +783,7 @@
                     ]
                 },
                 "Timeout": 10,
-                "Runtime": "nodejs6.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "KeepServiceNowGetIncidentStateWarmEventRule": {
@@ -971,7 +971,7 @@
                     ]
                 },
                 "Timeout": 10,
-                "Runtime": "nodejs6.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "KeepServiceNowGetLatestStateByPhoneWarmEventRule": {
@@ -1159,7 +1159,7 @@
                     ]
                 },
                 "Timeout": 10,
-                "Runtime": "nodejs6.10"
+                "Runtime": "nodejs10.x"
             }
         },
         "KeepServiceNowIntegrationTestWarmEventRule": {


### PR DESCRIPTION
CloudFormation templates in connect-integration-servicenow-itsm have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.